### PR TITLE
docs: correct comments describing tooling this repo does not ship

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,15 @@
 # Dependabot — automated dependency updates.
 #
 # WHY THIS EXISTS. This tree once carried a pile of open advisories with nothing
-# watching it. `./build.sh` stage 8 now fails the build on any HIGH or CRITICAL
+# watching it. `./build.sh` stage 7 now fails the build on any HIGH or CRITICAL
 # advisory, so the problem cannot ship — but a gate only speaks when somebody
 # runs it. Dependabot is what turns "we would have found out eventually" into a
 # pull request that arrives on its own.
 #
 # A Dependabot pull request can go green here without help: ci.yml triggers on
-# `pull_request` with no branch filter, so the branch gets the full nine-stage
-# gate, and no stage needs a secret (integration.yml, the only credentialed
-# workflow, deliberately has no `pull_request` trigger). A bump that clears an
-# advisory therefore arrives already proven.
+# `pull_request` with no branch filter, so the branch gets the full eight-stage
+# gate, and no stage of that gate needs a secret. A bump that clears an advisory
+# therefore arrives already proven.
 #
 # REVIEWERS ARE DELIBERATELY NOT LISTED. Dependabot's pull requests are ordinary
 # pull requests, so .github/CODEOWNERS assigns them like any other change. One

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,10 @@ jobs:
       # or process substitution, both of which preserve the exit status.
       #
       # build.sh itself runs, in order and failing fast: npm ci, prettier
-      # --check, eslint, tsc --noEmit, tsc build, jest + coverage thresholds,
-      # the integration tooling's offline self-test, npm audit (fails on
-      # HIGH/CRITICAL), and a gitleaks secret scan. Nine stages, all hermetic —
-      # no credentials, no network beyond the registry install and the gitleaks
-      # download above.
+      # --check, eslint, tsc --noEmit, tsc build, jest + coverage thresholds
+      # (and the coverage-floor check), npm audit (fails on HIGH/CRITICAL), and
+      # a gitleaks secret scan. Eight stages, all hermetic — no credentials, no
+      # network beyond the registry install and the gitleaks download above.
       #
       # REPO_IS_FORK is the one thing the gate cannot work out for itself.
       # The test suite cross-checks the repository slug that the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,8 @@ export default tseslint.config(
       "coverage/**",
       "node_modules/**",
       "tastytrade-llms-txt-docs/**",
-      // Local-only dev tooling (gitignored); not part of the linted source.
+      // Local-only developer tooling. /dev is gitignored and is never part of
+      // a clone, so this entry only bites in a working tree that has one.
       "dev/**",
     ],
   },
@@ -21,8 +22,8 @@ export default tseslint.config(
     // The flat config sets no environment globals, and `src/` only escapes
     // `no-undef` because typescript-eslint waives that rule for .ts files —
     // TypeScript already resolves globals through @types/node. Untyped .mjs
-    // (the integration runner, and any future script) gets no such waiver, so
-    // `console`, `process` and the timer functions read as undefined.
+    // (this config, jest.config.mjs, scripts/, and any future script) gets no
+    // such waiver, so `console`, `process` and the timers read as undefined.
     //
     // Declaring the runtime is the honest fix; switching `no-undef` off would
     // lose a real check.


### PR DESCRIPTION
## Summary

Three comments described build stages and files that are not part of this repository. This corrects each against the tree as it stands. Comments only; no behaviour changes.

`build.sh` has eight stages — install, format, lint, typecheck, build, test with coverage floors, audit, secrets. The gate's own output confirms the numbering: `npm audit` announces itself as `[7/8]`, and the final line prints `all 8 gates passed`.

## Changes

**`.github/workflows/ci.yml`** — the block above the `Quality gate` step listed the stages as including an integration self-test and concluded "Nine stages". It now lists the eight stages in the order the script runs them, with the coverage-floor check named alongside the Jest stage it belongs to.

**`.github/dependabot.yml`** — the header supported "no stage needs a secret" with a parenthetical naming `integration.yml` as the only credentialed workflow. That file is not part of this repository, and the claim holds without the qualification, so the parenthetical is removed. The stage count and audit stage number in the same sentence are corrected alongside it.

**`eslint.config.mjs`** — the `dev/**` ignore is kept. `/dev` is gitignored (`.gitignore` line 21) and `.prettierignore` covers it too, so the entry serves a live convention: local scratch tooling lands there and should not be linted, and removing the entry would leave Prettier and ESLint disagreeing about the same directory. The comment now states that the directory is absent from a clone. Separately, the `no-undef` block named an integration runner as the untyped `.mjs` needing Node globals declared; the files that are present — this config, `jest.config.mjs`, and `scripts/` — are named instead.

## Verification

`./build.sh` in the branch worktree, exit status captured directly as `rc=$?`: **exit 0**, 8/8 stages. 2,935 tests across 50 suites, coverage thresholds and floors met, `npm audit` clean, gitleaks clean across 148 tracked files. That run is also the evidence for the stage count and numbering above.

A sweep for comments citing paths absent from this repository returns clean after the change:

```
git grep -InP 'integration/|integration\.yml|docs/RISK|CHANGELOG|CODE_OF_CONDUCT|PROVENANCE\.md|verify-plan|smoke-test|self-test' -- . ':!tastytrade-llms-txt-docs'
```

That pattern deliberately omits `release.yml`. Three comments cite it — `dependabot.yml:78`, `ci.yml:84`, `ci.yml:144` — and #4 adds `.github/workflows/release.yml`, which makes all three correct. They are left alone here rather than edited and then re-edited.

## Merge order

Independent. The three `release.yml` references already exist verbatim on `main` and are untouched by this diff, so landing this ahead of #4 introduces no new inaccuracy — it leaves an existing one in place until #4 lands.

## Follow-up (not in this PR)

- `ci.yml` sets a `REPO_IS_FORK` environment variable that nothing currently reads. Resolving it means either removing the `env:` entry or adding the check it feeds, which is a workflow change rather than a comment correction.
- `.github/dependabot.yml` line 94 refers to three workflows sharing largely the same actions. That line sits in the region #4 touches, so it is better updated once #4 lands.

Comments referencing `release.yml` are left as they are, since #4 adds that file.
