### PR TITLE
ci: publish the release image from a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,490 @@
+name: Release (publish container image)
+
+# ---------------------------------------------------------------------------
+# Publishes the container image that server.json advertises.
+#
+# WHY THIS EXISTS. server.json tells the MCP registry — and therefore every
+# client that reads it — to `docker pull
+# ghcr.io/tastytrade/tastytrade-mcp:<version>`. Nothing else publishes that
+# image: ci.yml's docker job is build-only (`push: false`). This workflow is
+# what produces the advertised artifact, so that it carries provenance,
+# reproducible inputs, and a guarantee that it was built from the tagged
+# commit.
+#
+# server.json is the SOURCE OF TRUTH for what gets pushed. This workflow reads
+# the image reference out of it rather than repeating it, and refuses to publish
+# unless the git tag, package.json, and every mention of the image inside
+# server.json agree on one version. The cross-check runs in both directions:
+# the tag must match every mention, and every mention must match the tag, so
+# the image and the documentation always name the same version.
+#
+# TRIGGER. Tag pushes only. Not `workflow_dispatch`: a dispatch can be aimed at
+# an arbitrary branch, and a publish from an untagged tree produces exactly the
+# unattributable artifact this workflow exists to eliminate. Re-run a failed
+# publish from the Actions UI — that re-runs against the same tag.
+# ---------------------------------------------------------------------------
+on:
+  push:
+    tags:
+      - "v*"
+
+# Deny by default; each job opts into the minimum it needs.
+permissions: {}
+
+# Never cancel a publish in flight: cancelling mid-push can leave a partial
+# multi-arch manifest in the registry, so a slow release is the outcome to
+# prefer.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # A tag must not publish code that cannot pass the gate, and this job is the
+  # ONLY thing that guarantees it.
+  #
+  # ci.yml does not cover the tag path at all: its push trigger is scoped
+  # (`push: branches: [main]`), so a tag push never starts it. A tag cut on a
+  # commit that never went through main would otherwise be published with the
+  # gate never having run. Even for a tag on main, ci.yml is a separate workflow
+  # with no ordering relationship to this one, so its result cannot be depended
+  # on. Running the gate here as a prerequisite is what makes the publish
+  # fail-closed rather than merely likely-verified.
+  #
+  # Which means this job has to run the WHOLE gate, including the stages that
+  # need something installed first — see the gitleaks step below.
+  gate:
+    name: Quality gate (./build.sh)
+    # Only the upstream repository publishes. A fork that pushes a `v*` tag has
+    # no packages:write intent here, and its GITHUB_TOKEN carries write only for
+    # its own namespace, so a push to this repository's namespace is refused at
+    # the push itself. (`docker login ghcr.io` succeeds for any valid token, so
+    # the login step is not where a fork stops.) Skipping both jobs is the
+    # quieter outcome.
+    #
+    # THIS LITERAL IS LOAD-BEARING AND FAILS SILENTLY: after a rename or an org
+    # move, a stale string makes this `if` false, both jobs vanish, and a tag
+    # push publishes nothing while reporting nothing. Nothing in the gate checks
+    # it, so a rename has to update it here by hand, together with the slug in
+    # package.json and the image reference in server.json.
+    if: github.repository == 'tastytrade/tastytrade-mcp'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # merge-base needs both histories; the default shallow fetch has
+          # neither the default branch nor enough of the tag's ancestry.
+          fetch-depth: 0
+
+      # A tag can point at any commit, including one that never went through
+      # the default branch's merge requirements. Publishing is therefore gated
+      # on the tagged commit being reachable from the default branch, so the
+      # image can only ever hold code that was merged there. This runs before
+      # the gate itself so an unreachable tag stops in seconds.
+      - name: Require the tagged commit to be reachable from the default branch
+        run: |
+          git fetch --no-tags --depth=2147483647 origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::${GITHUB_SHA} is not reachable from origin/main. Tag a commit that has been merged to the default branch."
+            exit 1
+          fi
+          echo "${GITHUB_SHA} is reachable from origin/main."
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # build.sh's secret-scan stage SKIPS when gitleaks is absent, so that a
+      # contributor without it installed is never blocked. Installing it here is
+      # what turns that stage into an enforced check instead of a permanent
+      # skip — and the skip is silent, so a missing install reads as a pass.
+      #
+      # PINNED AND CHECKSUM-VERIFIED. This binary decides whether the secret
+      # gate passes, and it is fetched over the network at build time from a
+      # third party. A release asset can be replaced, a tag can be re-pointed,
+      # and a proxy can answer for github.com; without a checksum, any of those
+      # silently substitutes the judge. `sha256sum -c` exits non-zero on a
+      # mismatch and `set -euo pipefail` turns that into a failed job, so the
+      # only two outcomes are "the expected binary" and "a red build".
+      #
+      # THIS BLOCK IS DUPLICATED, BYTE FOR BYTE, IN BOTH
+      # .github/workflows/ci.yml AND .github/workflows/release.yml (gate job) —
+      # a composite action would have to live outside .github/workflows/. Bump
+      # the version in BOTH, and take the digest from that release's own
+      # gitleaks_<version>_checksums.txt, never from a third-party mirror.
+      - name: Install gitleaks (pinned, checksum-verified)
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL --retry 3 --retry-all-errors -o /tmp/gitleaks.tar.gz "$url"
+          printf '%s  %s\n' "$GITLEAKS_SHA256" /tmp/gitleaks.tar.gz | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version | grep -qF "$GITLEAKS_VERSION"
+
+      # Bare, never piped — a pipeline would report the exit status of the last
+      # command and turn a failed gate into a green publish. See ci.yml.
+      - name: Quality gate
+        run: ./build.sh
+
+  publish:
+    name: Publish image to GHCR
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      # Read the tree, write one package. Nothing else: this job does not need
+      # to read or write repository contents beyond the checkout, comment on
+      # anything, or mint an OIDC token.
+      #
+      # `id-token: write` is deliberately NOT granted. Provenance here comes
+      # from BuildKit (`provenance: mode=max` below), which records the build
+      # inputs into an in-toto attestation attached to the image in the
+      # registry and needs no OIDC token. Adding
+      # actions/attest-build-provenance on top would additionally require
+      # `id-token: write` and `attestations: write`; that buys a second,
+      # Sigstore-backed signature, at the cost of two more write scopes and
+      # another action in the supply chain. Not worth it while BuildKit
+      # provenance already answers "which commit, which builder, which
+      # inputs".
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      # ---------------------------------------------------------------------
+      # One version, agreed by three files, or nothing is published.
+      #
+      # The tag drives it; package.json and server.json must match it exactly.
+      # server.json is scanned as TEXT, not just at `packages[0].identifier`,
+      # because it names the image three times — once as the registry
+      # identifier and twice inside the `_meta` install documentation (the
+      # `docker pull` line and the ready-to-paste client config). A version
+      # bump that updates the identifier and forgets the docs would otherwise
+      # publish an image the copy-pasteable instructions cannot find.
+      # ---------------------------------------------------------------------
+      - name: Resolve and cross-check the release version
+        id: version
+        run: |
+          node --input-type=module <<'CHECK'
+          import { readFileSync, appendFileSync } from "node:fs";
+
+          const errors = [];
+          const die = () => {
+            for (const e of errors) console.log(`::error::${e}`);
+            console.log(
+              "::error::Refusing to publish. Fix the version in every file" +
+                " above, or delete and re-cut the tag.",
+            );
+            process.exit(1);
+          };
+
+          const tag = process.env.GITHUB_REF_NAME ?? "";
+          if (!tag.startsWith("v")) {
+            errors.push(`tag '${tag}' does not start with 'v'`);
+            die();
+          }
+          const version = tag.slice(1);
+          // The version becomes an OCI tag, so it must be one. Refusing
+          // anything but plain semver also keeps a hostile tag name from
+          // smuggling path or flag characters into an image reference.
+          if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/.test(version)) {
+            errors.push(
+              `tag '${tag}' is not v<semver>; refusing to derive an image tag` +
+                ` from it`,
+            );
+            die();
+          }
+
+          const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+          if (pkg.version !== version) {
+            errors.push(
+              `package.json version is '${pkg.version}', tag says '${version}'`,
+            );
+          }
+
+          const serverRaw = readFileSync("server.json", "utf8");
+          const server = JSON.parse(serverRaw);
+          if (server.version !== version) {
+            errors.push(
+              `server.json version is '${server.version}', tag says '${version}'`,
+            );
+          }
+
+          const oci = (server.packages ?? []).filter(
+            (p) => p.registryType === "oci",
+          );
+          if (oci.length !== 1) {
+            errors.push(
+              `server.json declares ${oci.length} oci packages; expected` +
+                ` exactly 1 (this workflow publishes one image)`,
+            );
+            die();
+          }
+          // `packages[].version` is optional, and the registry's reference
+          // document omits it from every OCI example: `identifier` already carries
+          // the tag, and a client that appends the field composes `<image>:t:t`.
+          // The version stays pinned four ways without it — the tag, package.json,
+          // the top-level `version`, and every textual mention checked below.
+          if (oci[0].version !== undefined) {
+            errors.push(
+              `server.json packages[0] sets version ('${oci[0].version}')` +
+                ` alongside an identifier that already carries the tag` +
+                ` ('${oci[0].identifier}'). A client that appends it composes the` +
+                ` tag twice. The registry's OCI examples set identifier alone.`,
+            );
+          }
+
+          // -----------------------------------------------------------------
+          // The MACHINE-READABLE install recipe has to compose to ONE reference.
+          //
+          // `_meta.install.docker` spells the command out in prose, and that prose
+          // is what a human copies; the `packages[0]` fields are what a registry
+          // client reads. The two are maintained separately, so this one is
+          // checked here.
+          //
+          // The reference document gives an OCI package a self-contained
+          // `identifier` and omits `registryBaseUrl`, while its npm, PyPI and
+          // NuGet examples pair a registry base with a bare package name. Setting
+          // both at once means a client that prefixes the base composes the host
+          // twice.
+          // -----------------------------------------------------------------
+          if (oci[0].registryBaseUrl !== undefined) {
+            errors.push(
+              `server.json packages[0] sets registryBaseUrl` +
+                ` ('${oci[0].registryBaseUrl}') alongside a self-contained` +
+                ` identifier ('${oci[0].identifier}'). A client that prefixes the` +
+                ` base composes the host twice. The registry's OCI examples set` +
+                ` identifier alone.`,
+            );
+          }
+
+          // Every secret the server cannot start without must be declared where
+          // a client will actually look for it. An OCI package's credentials
+          // reach the container from `environmentVariables`; a required secret
+          // that is not in that list is a server.json that installs cleanly and
+          // then answers `auth_failed` to every tool.
+          const declaredEnv = new Set(
+            (oci[0].environmentVariables ?? []).map((e) => e?.name),
+          );
+          for (const required of [
+            "TASTYTRADE_CLIENT_ID",
+            "TASTYTRADE_CLIENT_SECRET",
+            "TASTYTRADE_REFRESH_TOKEN",
+          ]) {
+            if (!declaredEnv.has(required)) {
+              errors.push(
+                `server.json packages[0].environmentVariables never declares` +
+                  ` ${required}, which the server cannot start without`,
+              );
+            }
+          }
+
+          const image = oci[0].identifier;
+          // Anchored, and no shell or reference metacharacters: this string is
+          // handed to docker as an image reference.
+          const IMAGE_RE =
+            /^ghcr\.io\/[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*:[0-9A-Za-z][0-9A-Za-z._-]*$/;
+          if (!IMAGE_RE.test(image)) {
+            errors.push(
+              `server.json identifier '${image}' is not a plain ghcr.io` +
+                ` <owner>/<name>:<tag> reference`,
+            );
+            die();
+          }
+          if (!image.endsWith(`:${version}`)) {
+            errors.push(
+              `server.json identifier '${image}' is not tagged '${version}'`,
+            );
+          }
+
+          // Every mention of the image anywhere in server.json, docs included.
+          const repo = image.slice(0, image.lastIndexOf(":"));
+          const mentions = [
+            ...serverRaw.matchAll(
+              new RegExp(
+                `${repo.replace(/[.\\/]/g, "\\$&")}:([^"\\s\\\\]+)`,
+                "g",
+              ),
+            ),
+          ].map((m) => m[1]);
+          if (mentions.length === 0) {
+            errors.push(`server.json never mentions '${repo}:<version>'`);
+          }
+          const wrong = [...new Set(mentions.filter((t) => t !== version))];
+          if (wrong.length > 0) {
+            errors.push(
+              `server.json mentions ${repo} at ${wrong
+                .map((t) => `'${t}'`)
+                .join(", ")}; the tag says '${version}'. Every mention,` +
+                ` including the _meta install docs, must be updated together.`,
+            );
+          }
+
+          if (errors.length > 0) die();
+
+          console.log(
+            `Version ${version} agreed by the tag, package.json and all` +
+              ` ${mentions.length} server.json mentions of the image.`,
+          );
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `version=${version}\nimage=${image}\n`,
+          );
+          CHECK
+
+      # PINNED BY COMMIT SHA, NOT BY MAJOR TAG. This job holds `packages: write`
+      # on ghcr.io/tastytrade/tastytrade-mcp — the image operators point at
+      # funded accounts. A git tag is mutable: whoever controls one of these
+      # repositories can re-point `v4` at any commit, and every workflow in the
+      # world that trusts the tag executes it on its next run, inside a job
+      # holding a registry write token. A digest cannot be re-pointed.
+      #
+      # EVERY action is pinned this way, `actions/*` included, and the rule has
+      # no first-party exemption. The argument above does not distinguish
+      # first-party from third-party, and neither does the exposure: the
+      # `actions/checkout` and `actions/setup-node` steps at the top of this job
+      # produce the working tree the image is then built from, so a tampered
+      # checkout ships an image whose BuildKit provenance attests to a commit
+      # its contents no longer match. OpenSSF Scorecard's Pinned-Dependencies
+      # check reads them the same way.
+      #
+      # The same reasoning already produced the hand-rolled `docker login`
+      # below. The version in the trailing comment is what the digest was, and
+      # Dependabot updates SHA pins and their comments together (see
+      # .github/dependabot.yml's github-actions entry), so this costs nothing
+      # ongoing.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # Plain `docker login` rather than an action: one fewer third-party
+      # dependency in the path that holds a registry write token. The token is
+      # piped on stdin, never placed on a command line where it would land in
+      # the process table, and never interpolated into the shell script itself.
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      # A published version is immutable in practice: clients pin the exact tag
+      # out of server.json, so silently replacing its contents would change what
+      # an already-audited reference resolves to. Re-cut a new version instead.
+      #
+      # Three outcomes, not two. `inspect` exiting non-zero is NOT by itself
+      # proof the tag is free — a 500 from the registry, a rate limit, or an
+      # auth hiccup fails the same way as "does not exist". Discarding the
+      # difference would make a transient registry error silently authorise the
+      # overwrite this step exists to prevent, so an inconclusive answer is
+      # treated as a refusal and the operator re-runs.
+      #
+      # "Absent" must be asserted ABOUT THIS REFERENCE. Grepping the output for
+      # a bare "not found" is not enough: `docker: command not found` from the
+      # shell matches it too, which turns a missing toolchain into a green
+      # go-ahead. So the message must either name the registry's own
+      # `manifest unknown`, or mention the image reference alongside the
+      # not-found wording.
+      - name: Refuse to overwrite an already-published version
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+        run: |
+          command -v docker >/dev/null 2>&1 || {
+            echo "::error::docker is unavailable on this runner, so whether ${IMAGE} is already published cannot be established. Refusing to push."
+            exit 1
+          }
+
+          rc=0
+          out=$(docker buildx imagetools inspect "$IMAGE" 2>&1) || rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::${IMAGE} is already published. A released version is immutable — bump the version in package.json and server.json and cut a new tag."
+            exit 1
+          fi
+
+          absent=0
+          if printf '%s' "$out" | grep -qiE 'manifest[ _]unknown'; then
+            absent=1
+          elif printf '%s' "$out" | grep -qF "$IMAGE" &&
+            printf '%s' "$out" | grep -qiE 'not found|404'; then
+            absent=1
+          fi
+
+          if [ "$absent" -eq 1 ]; then
+            echo "${IMAGE} is not yet published; proceeding."
+            exit 0
+          fi
+
+          echo "::error::Could not determine whether ${IMAGE} is already published (docker exited ${rc}). Refusing to push rather than risk overwriting a released version. Re-run this workflow once the registry is reachable."
+          printf '%s\n' "$out"
+          exit 1
+
+      # Only the exact version tag is pushed. No `latest`, and no floating `1`
+      # or `1.0`: this server places orders, and a floating tag means an
+      # operator's `docker pull` can change the code that trades without any
+      # change on their side. server.json pins the exact version for the same
+      # reason.
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.version.outputs.image }}
+          # BuildKit provenance (SLSA in-toto) plus an SBOM, attached to the
+          # image in the registry. `mode=max` records the full build inputs,
+          # which is the part that makes the attestation useful for answering
+          # "was this built from that commit".
+          provenance: mode=max
+          sbom: true
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      # ONE-TIME MANUAL STEP, called out here because it cannot be automated
+      # from inside this job. A new GHCR package is created PRIVATE, so after
+      # the first successful publish an anonymous `docker pull` of the image
+      # server.json advertises still cannot fetch it. Making a package public
+      # is a package-settings change, not something the job-scoped
+      # GITHUB_TOKEN can do, so the summary below repeats it on every release
+      # until it is done.
+      - name: Summary
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+        run: |
+          {
+            echo "### Published"
+            echo
+            echo '```'
+            echo "docker pull ${IMAGE}"
+            echo '```'
+            echo
+            echo "Built from \`${GITHUB_SHA}\` for linux/amd64 and linux/arm64,"
+            echo "with BuildKit provenance and an SBOM attached in the registry."
+            echo
+            echo "**First release only:** a new GHCR package is private by default."
+            echo "Until it is set to public under the package's settings, this"
+            echo "\`docker pull\` fails for anyone outside the org even though"
+            echo "\`server.json\` advertises it. Check it once, then ignore this note."
+          } >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

`server.json` advertises `ghcr.io/tastytrade/tastytrade-mcp:1.0.0` as an installable OCI package. `ci.yml`'s `docker` job builds the image but does not push it (`push: false`), so there is no path from a tag to a published artifact. This adds one.

`release.yml` triggers on `v*` tag pushes only. `workflow_dispatch` is deliberately not offered: it can be aimed at an arbitrary branch, and the resulting image would not correspond to a tagged commit.

Two jobs:

- **`gate`** first requires the tagged commit to be reachable from the default branch. A tag can point at any commit, so this keeps a published image to code that went through the default branch's own merge requirements, and an unreachable tag stops in seconds rather than after a full gate run. It then runs `./build.sh`. `ci.yml` does not cover this path — its `push` trigger is scoped to `main`, so a tag push never starts it, and it is a separate workflow with no ordering relationship to this one. Running the gate here as a prerequisite makes the publish fail-closed.
- **`publish`** derives the image reference from `server.json` rather than repeating it, and pushes only when the tag, `package.json` and every mention of the image in `server.json` agree on one version. It declines to overwrite an already-published tag and treats an inconclusive registry answer as a refusal. Only the exact version tag is pushed — no `latest`, no floating major — so an operator's `docker pull` resolves to fixed code.

Provenance comes from BuildKit (`provenance: mode=max`) with an SBOM attached in the registry, which needs no OIDC token. The `publish` job takes `contents: read` plus `packages: write` and nothing else.

### Follows the settled OCI declaration (#9)

The version step's OCI checks follow the shape the registry's reference document describes: an `identifier` that carries the host and the tag on its own, with `registryBaseUrl` and `packages[].version` absent. Setting either alongside a self-contained identifier makes a client compose the host or the tag twice, so each is refused by name.

The version stays pinned four ways without `packages[].version`: the tag, `package.json`, the top-level `$.version`, and every textual mention of the image inside `server.json`.

**Merge #9 first.** Extracted this branch's version step and ran it against both trees with `GITHUB_REF_NAME=v1.0.0`:

| tree | exit | result |
| --- | --- | --- |
| #9 (settled declaration) | `0` | `Version 1.0.0 agreed by the tag, package.json and all 3 server.json mentions of the image`; emits `image=ghcr.io/tastytrade/tastytrade-mcp:1.0.0` |
| current `main` | `1` | refuses, naming both the doubled tag and the doubled host |

### One manual step after the first publish

A new GHCR package is created **private**. After the first successful publish, an anonymous `docker pull` of the advertised image cannot fetch it until the package is made public, which is a package-settings change the job-scoped `GITHUB_TOKEN` cannot perform. The workflow's summary step prints this on every release until it is done.

## Verification

- **`./build.sh` — exit code 0**, captured as `rc=$?` rather than read out of the log. All 8 stages green: 50 suites / 2,935 tests, coverage floors met, `npm audit` clean, gitleaks clean across 149 tracked files.
- **YAML parses** (`python3 -c "import yaml; yaml.safe_load(...)"`), and `jobs.publish.permissions` reads back as `{'contents': 'read', 'packages': 'write'}`.
- **`prettier --check`** passes on the file, which is what stage 2 of the gate enforces.
- **Gitleaks block byte-identity confirmed under `diff`** — zero differing lines between `ci.yml`'s install step and this one. Same version (`8.30.1`), same digest.
- **The pinned gitleaks digest matches upstream.** `gitleaks_8.30.1_checksums.txt` from the release lists `551f6fc8…eb  gitleaks_8.30.1_linux_x64.tar.gz`, matching `GITLEAKS_SHA256`.
- **Every `uses:` is pinned by full commit SHA with a version comment**, each resolved against its upstream tag via `gh api repos/<action>/git/ref/tags/<tag>`: `actions/checkout` v7.0.1, `actions/setup-node` v7.0.0, `docker/setup-qemu-action` v4.2.0, `docker/setup-buildx-action` v4.3.0, `docker/build-push-action` v7.3.0. All resolve to the pinned SHA, all are commit objects, and they match the digests `ci.yml` uses, so Dependabot's grouped `github-actions` update moves both files together.
- `ci.yml` and `.github/dependabot.yml` are untouched; this PR adds exactly one file.
