### PR TITLE
chore: align package metadata with the supported install paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,8 @@
 #
 # Nothing in the repository needs it committed: the Docker image compiles it in
 # its own build stage, and ./build.sh builds before it tests. `files: ["dist",
-# …]` in package.json describes the PUBLISHED TARBALL, not version control — so
-# a release must compile before `npm pack` / `npm publish` runs. Run
-# `npm run build` after a fresh clone.
+# …]` in package.json describes the contents of an `npm pack` tarball, not
+# version control. Run `npm run build` after a fresh clone.
 /dist
 
 # Local-only developer tooling (live integration harness, scratch, etc.) —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tastytrade/mcp-server",
   "version": "1.0.0",
+  "private": true,
   "description": "Model Context Protocol server for the tastytrade brokerage API: tools, resources and prompts for quotes, positions and order flow, with every money-moving action behind a dry-run confirmation gate.",
   "license": "MIT",
   "author": "tastytrade",
@@ -26,9 +27,6 @@
   ],
   "type": "module",
   "main": "dist/index.js",
-  "bin": {
-    "tastytrade-mcp-doctor": "dist/doctor.js"
-  },
   "engines": {
     "node": ">=22"
   },
@@ -65,8 +63,5 @@
     "ts-jest": "^29.4.5",
     "typescript": "^5.3.0",
     "typescript-eslint": "^8.60.1"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * `tastytrade-mcp-doctor` — the operator preflight command.
+ * The operator preflight command, run as `npm run doctor` or
+ * `node dist/doctor.js`.
  *
  * When the credentials are wrong, this server fails the same way on every tool
  * call: `auth_failed`, with nothing saying which of the four things is broken.
@@ -2555,10 +2556,10 @@ function jsonTruncation(tally: BoundedTally): Record<string, number> {
 // CLI
 // ---------------------------------------------------------------------------
 
-export const USAGE = `tastytrade-mcp-doctor — preflight the tastytrade MCP server's configuration
+export const USAGE = `Preflight the tastytrade MCP server's configuration
 
 Usage:
-  tastytrade-mcp-doctor [doctor] [--json] [${SHOW_ACCOUNTS_FLAG}] [--help]
+  node dist/doctor.js [doctor] [--json] [${SHOW_ACCOUNTS_FLAG}] [--help]
 
 Options:
   --json             Emit one JSON object instead of the human report.
@@ -2637,7 +2638,7 @@ export async function main(
 ): Promise<number> {
   const options = parseArgs(argv);
   if (options.error) {
-    err(`tastytrade-mcp-doctor: ${options.error}\n\n${USAGE}`);
+    err(`doctor: ${options.error}\n\n${USAGE}`);
     return EXIT_USAGE;
   }
   if (options.help) {
@@ -2654,10 +2655,11 @@ export async function main(
 /**
  * True when this module is the process entry point.
  *
- * `process.argv[1]` is the path that was executed, which for an installed `bin`
- * is a symlink in `node_modules/.bin/`, while `import.meta.url` is always the
- * real file. Comparing them raw makes an npm-installed doctor silently do
- * nothing, so both sides are resolved through realpath first.
+ * `process.argv[1]` is the path that was executed, which may be a symlink — a
+ * link an operator puts on PATH, or one a container image layer creates —
+ * while `import.meta.url` is always the real file. Comparing them raw makes an
+ * invocation through such a link silently do nothing, so both sides are
+ * resolved through realpath first.
  */
 export function isDirectInvocation(
   argv1: string | undefined,

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -364,18 +364,18 @@ describe("configuration copied from the dispatcher", () => {
     expect(check.data?.limit).toBe(DEFAULT_MAX_ORDER_NOTIONAL_USD);
   });
 
-  it("is wired up as a bin entry pointing at the compiled doctor", () => {
+  it("is not published to npm, so it exposes no installable command", () => {
     const pkg = JSON.parse(
       readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
-    ) as { bin?: Record<string, string>; files?: string[] };
-    expect(pkg.bin).toBeDefined();
-    const targets = Object.values(pkg.bin ?? {});
-    expect(targets).toContain("dist/doctor.js");
-    // dist/ must stay in `files` or an installed package has no bin target.
-    expect(pkg.files).toContain("dist");
+    ) as { private?: boolean; bin?: unknown; publishConfig?: unknown };
+    // The supported install paths are clone-and-build and the container image.
+    // `private` is what makes that stick: without it a publish still succeeds.
+    expect(pkg.private).toBe(true);
+    expect(pkg.bin).toBeUndefined();
+    expect(pkg.publishConfig).toBeUndefined();
   });
 
-  it("keeps the shebang first in the source, so the bin link is executable", () => {
+  it("keeps the shebang first in the source, so dist/doctor.js runs directly", () => {
     const source = readFileSync(
       path.join(REPO_ROOT, "src", "doctor.ts"),
       "utf8",
@@ -3432,17 +3432,15 @@ describe("isDirectInvocation", () => {
     );
   });
 
-  it("resolves an npm bin symlink to the real file", () => {
-    // The case that matters: an installed package runs
-    // node_modules/.bin/tastytrade-mcp-doctor, which is a symlink. Comparing the
+  it("resolves a symlink on PATH to the real file", () => {
+    // The case that matters: argv[1] is a link an operator put on PATH, or one
+    // a container layer created, rather than the file itself. Comparing the
     // paths raw would make the CLI silently do nothing.
     const realpath = (p: string) =>
-      p === "/pkg/node_modules/.bin/tastytrade-mcp-doctor"
-        ? "/pkg/dist/doctor.js"
-        : p;
+      p === "/usr/local/bin/tastytrade-doctor" ? "/pkg/dist/doctor.js" : p;
     expect(
       isDirectInvocation(
-        "/pkg/node_modules/.bin/tastytrade-mcp-doctor",
+        "/usr/local/bin/tastytrade-doctor",
         moduleUrl,
         realpath,
       ),

--- a/test/e2e/configuration.test.ts
+++ b/test/e2e/configuration.test.ts
@@ -1308,8 +1308,8 @@ describe("the library barrel is not an entrypoint", () => {
 
   it("still recognises the entry module when it is launched through a symlink", async () => {
     // Node resolves an ESM specifier to the real path, so `import.meta.url` is
-    // dereferenced while argv[1] is whatever the caller typed. An npm `bin`
-    // shim, a /usr/local/bin link or a container layer makes those two
+    // dereferenced while argv[1] is whatever the caller typed. A
+    // /usr/local/bin link or a container layer makes those two
     // spellings differ, and treating that as "imported" would silently start
     // nothing — the quietest possible failure for an entrypoint.
     const { isEntryModule } = await import("../../src/index.js");


### PR DESCRIPTION
## Summary

This server offers two install paths: clone-and-build, and the published container image. `server.json` documents both and states that npm is not a distribution channel.

`package.json` carried two fields that describe an npm install instead. `bin` declares a command name that only exists once a package is installed from a registry; `publishConfig` sets registry access. This removes both and adds `private`, so the package metadata and the documented install paths describe the same thing.

`private` also means `npm publish` exits non-zero rather than succeeding, which is the point of setting it rather than simply omitting the other two.

## Changes

- **`package.json`** — remove `bin` and `publishConfig`; add `"private": true`. `files` and `prepack` are unchanged: they govern `npm pack`, which remains useful locally for inspecting a tarball.
- **`src/doctor.ts`** — the `Usage:` line printed by `--help` showed `tastytrade-mcp-doctor`, the command name that `bin` would have installed. It now shows `node dist/doctor.js`, which works on both supported install paths. `npm run doctor` also still works and is what the README leads with.
- **`test/doctor.test.ts`** — the test covering `bin` now asserts the package is not registry-publishable: `private` is true and neither field is present. The neighbouring shebang test keeps its assertion; only its name changes, since `dist/doctor.js` is executed directly rather than through an installed link.
- **`src/doctor.ts`, `test/doctor.test.ts`, `test/e2e/configuration.test.ts`** — three comments explained why `argv[1]` is resolved through `realpath` in terms of an npm `bin` shim in `node_modules/.bin/`. That resolution is still required, because `argv[1]` can be a link an operator puts on PATH or one a container image layer creates. The logic is unchanged; the comments and one test fixture now name those cases instead, so nothing in the tree describes a scenario this change rules out.

## Verification

- `./build.sh` — exit code `0`, captured as `rc=$?`. All 8 stages: prettier, eslint, `tsc --noEmit`, build, Jest with coverage thresholds and floor ratchet, `npm audit`, gitleaks across 148 tracked files.
- 2,935 tests across 50 suites pass. The retargeted symlink test exercises the same `isDirectInvocation` branch as before — only the fixture path changed.
- Confirmed nothing else depends on the removed fields:
  - `Dockerfile` entrypoint is `["node", "dist/index.js"]`.
  - `npm run doctor` is a script (`node dist/doctor.js`), not the `bin`.
  - The release workflow in #4 reads only `pkg.version` from `package.json` and publishes no npm artifact.
  - `package-lock.json`'s root entry does not declare `bin`, so it stays in sync. Verified directly: `npm ci` against this branch's `package.json` and `package-lock.json` exits `0`.
- No remaining reference in `src/` or `test/` to `node_modules/.bin/tastytrade-mcp-doctor` or to an npm-installed invocation.

## Merge order

Independent of #3, #4, #6 and #7.
