### PR TITLE
fix: let a registry client build the docker command for the OCI package

### DIFF
--- a/server.json
+++ b/server.json
@@ -19,24 +19,6 @@
       "transport": {
         "type": "stdio"
       },
-      "runtimeArguments": [
-        {
-          "type": "positional",
-          "value": "run",
-          "valueHint": "run"
-        },
-        {
-          "type": "positional",
-          "value": "-i",
-          "valueHint": "-i",
-          "description": "Required. This is a stdio MCP server; without -i Docker leaves stdin detached, the transport reads EOF immediately, and the container exits with no output."
-        },
-        {
-          "type": "positional",
-          "value": "--rm",
-          "valueHint": "--rm"
-        }
-      ],
       "environmentVariables": [
         {
           "name": "TASTYTRADE_API_URL",


### PR DESCRIPTION
## Summary

`server.json`'s OCI package declared three positional `runtimeArguments` — `run`, `-i` and `--rm`. The registry schema describes `runtimeArguments` as "a list of arguments to be passed to the package's runtime command (such as `docker` or `npx`)", so a client builds `docker <runtimeArguments...> <identifier>` and supplies the subcommand and the flags a stdio container needs itself.

With those three declared, the invocation a client constructs is:

```
docker run -i --rm run -i --rm ghcr.io/tastytrade/tastytrade-mcp:1.0.0
```

where `run` is resolved as the image name.

This removes the array so the client constructs the invocation. `runtimeHint: "docker"` stays, so the runtime is still named explicitly. `_meta.install.docker` already spells the same command out in prose for a human reader and is unchanged.

## Changes

**`server.json`** — remove `packages[0].runtimeArguments`. 18 lines deleted, nothing else touched.

## Verification

**The registry's own published entries.** Paged through 800 servers on `registry.modelcontextprotocol.io/v0/servers`. Two declare an OCI package, and neither declares `runtimeArguments` at all. Since `docker <image>` on its own is not a runnable command, the client must be supplying `run`, which is what makes declaring it here a duplicate.

**The version check from #4, run directly against both trees.** That step is the thing that gates a release on this file, so it is the relevant oracle. Extracted from `.github/workflows/release.yml` on the #4 branch and executed with `GITHUB_REF_NAME=v1.0.0`:

| Tree | Exit | Output |
| --- | --- | --- |
| `origin/main` | `1` | reports the duplication and refuses to publish |
| this branch | `0` | `Version 1.0.0 agreed by the tag, package.json and all 3 server.json mentions of the image` |

The passing run writes `version=1.0.0` and `image=ghcr.io/tastytrade/tastytrade-mcp:1.0.0`.

**`./build.sh` — exit code 0**, captured as `rc=$?`. All 8 stages: prettier, eslint, `tsc --noEmit`, build, 2,935 tests across 50 suites with coverage thresholds and floors, `npm audit` clean, gitleaks clean across 148 tracked files.

**Scope.** No test or source file references `runtimeArguments`, so nothing else depends on it. The file is Prettier-formatted, so the diff is the removal and nothing else.

## Merge order

Independent of #3, #4 and #5 — it touches only `server.json`. It is a prerequisite for the first `v1.0.0` tag: #4's version step refuses to publish until this lands.