### PR TITLE
docs: include the clone step in the README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ point it at production.
 ## Install
 
 ```bash
+git clone https://github.com/tastytrade/tastytrade-mcp.git
+cd tastytrade-mcp
 npm ci
 npm run build
 ```


### PR DESCRIPTION
## Summary

The README's Install section starts at `npm ci`, which assumes the reader already has the repository on disk. A reader following the README from the top has nothing to run it in.

`server.json`'s `_meta.install.cloneAndBuild.setup` lists all four steps. The README now matches it.

## Changes

**`README.md`** — two lines added to the Install block:

```bash
git clone https://github.com/tastytrade/tastytrade-mcp.git
cd tastytrade-mcp
npm ci
npm run build
```

## Verification

- `./build.sh` — exit code `0`, captured as `rc=$?`. All 8 stages, including `prettier --check` on the changed file.
- The clone URL matches `server.json`'s `repository.url` and the `cloneAndBuild.setup` sequence, so the two documents now give the same instructions.

## Follow-up (not in this PR)

The README documents only the clone-and-build path. `server.json` describes a second supported path using the published container image, which the README does not mention. That section is better added once the image is published, so the `docker pull` line it would carry resolves.