### PR TITLE
test: make the normalizeKeyName scaling assertion noise-proof

### DIFF
--- a/test/safety/errors.test.ts
+++ b/test/safety/errors.test.ts
@@ -500,10 +500,45 @@ describe("normalizeKeyName is linear in key length", () => {
     expect(Date.now() - startedAt).toBeLessThan(1_000);
   }, 120_000);
 
-  it("costs ~2x, not ~4x, for twice the key length", () => {
-    const at100k = cheapestMs(() => isSecretKey("A".repeat(100_000)));
-    const at200k = cheapestMs(() => isSecretKey("A".repeat(200_000)));
-    expect(at200k / at100k).toBeLessThan(3.0);
+  // A ratio is only as stable as the noisier of its two samples, and at 100,000
+  // characters the whole call costs ~2 ms — small enough that one scheduling
+  // hiccup on a shared runner doubles it. Doubling the length predicts ~2 and
+  // measures 1.9-2.3 unloaded, so a bound of 3.0 left barely 1.3x of headroom
+  // and went red at 3.62 on CI.
+  //
+  // Two changes make the same claim without that fragility. Span 16x instead of
+  // 2x, so linear predicts ~16 while the quadratic implementation this replaced
+  // predicts ~256 and the bound can sit far from both. And note which direction
+  // noise pushes: the numerator is now tens of milliseconds, while the
+  // denominator is still the same ~2 ms sample as before. That is safe rather
+  // than incidental — noise only ever ADDS time, so a slow denominator can only
+  // make the ratio smaller and the assertion pass. The bound is therefore set
+  // by how large a genuine regression makes the ratio, not by how precisely the
+  // small sample can be timed. Do not tighten it toward the measured ~18 on the
+  // assumption that both samples are now precise; the denominator is not.
+  it("grows with the key length, not with its square", () => {
+    const at100k = cheapestMs(() => isSecretKey("A".repeat(100_000)), 2_000);
+
+    // Asserted before the larger sample is taken, so a quadratic scan fails
+    // here in seconds with a legible message rather than spending twenty
+    // minutes on 1,600,000 characters and reporting a timeout. This one takes
+    // ~2 ms, so the ceiling is 250x above it; the quadratic version took 4.8 s
+    // at this size, so the ceiling is ~10x below that. The wide side is the
+    // one that matters for flakiness.
+    expect(at100k).toBeLessThan(500);
+
+    const at1600k = cheapestMs(() => isSecretKey("A".repeat(1_600_000)), 4_000);
+
+    // Measured ~18 for this 16x span, against ~16 predicted for a linear scan
+    // and ~256 for a quadratic one. 48 is 2.6x above what is observed and 5x
+    // below what a regression would produce.
+    expect(at1600k / at100k).toBeLessThan(48);
+
+    // An absolute ceiling as well, because it does not depend on the ratio
+    // holding. Measured ~37 ms, so this sits ~54x above what a linear scan
+    // costs. The quadratic version took 4.8 s at 100,000 characters, which
+    // scales to ~20 minutes at 1,600,000 — about 600x this bound.
+    expect(at1600k).toBeLessThan(2_000);
   }, 180_000);
 });
 


### PR DESCRIPTION
## Summary

`normalizeKeyName is linear in key length › costs ~2x, not ~4x, for twice the key length` compares wall-clock timings at 100,000 and 200,000 characters and requires the ratio to stay under `3.0`. It went red on CI at `3.62` during #5, on a diff touching `.gitignore`, `package.json`, `src/doctor.ts` and two unrelated test files.

The bound is the problem, not the run. Doubling the length predicts ~2, and measured best-of-9 on an idle machine:

| length | best | ratio vs previous |
| --- | --- | --- |
| 50,000 | 1.048 ms | — |
| 100,000 | 2.052 ms | 1.96 |
| 200,000 | 4.196 ms | 2.04 |
| 400,000 | 8.721 ms | 2.08 |
| 800,000 | 16.220 ms | 1.86 |
| 1,600,000 | 37.351 ms | 2.30 |

So `3.0` left roughly 1.3x of headroom over the worst unloaded sample, and at 100,000 characters the whole call costs ~2 ms — small enough that one scheduling hiccup dominates it. This sits in a required status check, so the cost is a randomly red gate and the habit of re-running red builds.

## Changes

**`test/safety/errors.test.ts`** — one test rewritten. The property asserted is unchanged: growth is linear in the key length, not quadratic.

- **An absolute ceiling on the smaller sample, asserted before the larger one is measured.** The call takes ~2 ms, so `500 ms` sits **250x above** it. The quadratic implementation this guards against took 4.8 s at the same size, so the ceiling sits about **10x below** that — and 6.8x below the 3,381 ms actually measured with the regression restored. The wide side is the one that governs flakiness; the narrow side only has to be wide enough to catch the regression, and it is. Putting this first means a regression fails here in ~3 s with a legible message rather than spending twenty minutes on 1,600,000 characters and reporting a timeout.
- **A 16x span instead of 2x for the ratio.** A linear scan answers ~16, a quadratic one ~256. The bound of `48` is 2.6x above the measured ~18 and 5x below a regression. The samples are tens of milliseconds rather than ~2 ms, so timer granularity is a small fraction of each.
- **An absolute ceiling on the larger sample as well**, so the check does not rest on the ratio holding. Measured ~37 ms against `2,000 ms`, about 54x of headroom; a quadratic scan would need roughly 20 minutes there.

The sibling test (`classifies a 200,000-character uppercase key inside a 1s budget`) is unchanged.

## Verification

**The test still fails when it should.** Restored the quadratic regex in `src/safety/errors.ts`:

```
-  for (let i = 0; i < key.length; i++) { ...hand-written walk... }
+  key.replace(/([a-z0-9])([A-Z])/g, "$1-$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
```

Result:

```
✕ grows with the key length, not with its square (3383 ms)
  expect(received).toBeLessThan(expected)
  Expected: < 500
  Received:   3381.472791
  > 521 |     expect(at100k).toBeLessThan(500);
Tests: 1 failed
```

Fails in 3.4 s, at the intended assertion, with the intended message.

**The implementation was then restored byte-for-byte** — `git diff --quiet src/safety/errors.ts` clean — and the test passes **5 runs out of 5**: 312, 313, 317, 321, 315 ms.

**`./build.sh` — exit code 0**, captured as `rc=$?`. All 8 stages, 2,935 tests across 50 suites, coverage floors met, `npm audit` clean, gitleaks clean.

One file, test-only.
