### PR TITLE
fix: declare the OCI package the way the registry requires

### DIFF
--- a/server.json
+++ b/server.json
@@ -12,31 +12,11 @@
   "packages": [
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
       "identifier": "ghcr.io/tastytrade/tastytrade-mcp:1.0.0",
-      "version": "1.0.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"
       },
-      "runtimeArguments": [
-        {
-          "type": "positional",
-          "value": "run",
-          "valueHint": "run"
-        },
-        {
-          "type": "positional",
-          "value": "-i",
-          "valueHint": "-i",
-          "description": "Required. This is a stdio MCP server; without -i Docker leaves stdin detached, the transport reads EOF immediately, and the container exits with no output."
-        },
-        {
-          "type": "positional",
-          "value": "--rm",
-          "valueHint": "--rm"
-        }
-      ],
       "environmentVariables": [
         {
           "name": "TASTYTRADE_API_URL",


### PR DESCRIPTION
## Summary

The OCI package declared `registryBaseUrl` and a `packages[].version` alongside an `identifier` that already names the host and the tag, plus `runtimeArguments` declaring `run`, `-i` and `--rm`.

Two of those are **refused outright by the registry**. The third follows current published practice. This removes all three, leaving `identifier` to carry the reference alone.

## What settles it

**The registry's OCI validator, `internal/validators/registries/oci.go`:**

```go
if pkg.RegistryBaseURL != "" {
    return fmt.Errorf("OCI packages must not have 'registryBaseUrl' field - use canonical reference in 'identifier' instead (e.g., 'docker.io/owner/image:1.0.0')")
}
if pkg.Version != "" {
    return fmt.Errorf("OCI packages must not have 'version' field - include version in 'identifier' instead (e.g., 'docker.io/owner/image:1.0.0')")
}
if pkg.FileSHA256 != "" {
    return fmt.Errorf("OCI packages must not have 'fileSha256' field")
}
```

A submission carrying either field is rejected with those messages. `fileSha256` is already absent here, so that rule is satisfied. This is the authoritative rule, and it makes the first two removals mandatory rather than stylistic.

**`runtimeArguments` is a different case, and the distinction is worth being exact about: the validator says nothing about it.** Two things support removing it anyway.

The reference document's OCI examples declare only substantive flags — `--mount` for `docker.io/mcp/filesystem:1.0.2`, `--network` and `-e` for `docker.io/example/database-manager-mcp:3.1.0`, none at all for `quay.io/myorg/my-mcp-server:1.0.0`. None declares the subcommand or the container-mode flags.

And the entries that once did have moved off it:

| server | older version | current version (`isLatest`) |
| --- | --- | --- |
| `io.github.github/github-mcp-server` | declared `[run, -i, --rm, -e …]` up to and including **`0.21.0`**; absent from **`0.28.0`** onward | `1.11.0`: `[-p 127.0.0.1:8085:8085, -e GITHUB_OAUTH_CALLBACK_PORT, -e GITHUB_PERSONAL_ACCESS_TOKEN]` |
| `io.github.hashicorp/terraform-mcp-server` | declared `[run, --rm, -i, -e …]` up to **`0.4.0`**; dropped in **`0.5.0`** | `1.0.0`: `[-e TFE_ADDRESS, -e TFE_TOKEN, -e ENABLE_TF_OPERATIONS]` |

Retrieved from `/v0/servers/{name}/versions` and sorted numerically by version — 41 OCI versions for the first, of which 10 declare `run`, the last being `0.21.0`; 5 for the second. Sorting matters: the endpoint does not return them in version order, and reading the default order is how an earlier attempt at this change reached the opposite conclusion. A client reading the current entries must supply `docker run` and the stdio flags itself, since neither entry provides them. Declaring them here therefore adds a second copy of arguments the client already contributes.

## Changes

**`server.json`** — 20 deletions, one file, nothing added.

- **`registryBaseUrl`** removed — refused by the validator.
- **`packages[0].version`** removed — refused by the validator. The top-level `$.version` stays, as the reference examples set it.
- **`runtimeArguments`** removed — follows the reference examples and current published practice, as above.
- **`runtimeHint: "docker"` kept.** Valid, optional, and names the runtime explicitly. The schema associates it with `runtimeArguments` ("should be provided when `runtimeArguments` are present") but does not require removing it.
- **`_meta.install.docker` unchanged** — the human-facing `docker run -i --rm --env-file … <image>` instructions were already correct, and remain the path a person copies.

## Verification

- **Schema-valid before and after.** Validated against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` with `jsonschema` 4.25.1: 0 errors both ways. That schema declares `"$schema": "http://json-schema.org/draft-07/schema#"` and uses `definitions`, so `validator_for()` selects `Draft7Validator`; `2025-12-11` in the URL is the registry's own schema date, not a JSON Schema draft. `Package.required` is only `["registryType", "identifier", "transport"]`, so the schema alone does not decide this question — the registry-side validator quoted above does.
- **The three textual mentions of the image are preserved** (`identifier`, and both copies inside `_meta.install.docker`), so #4's cross-check over all mentions still compares the same three.
- **`./build.sh` — exit code 0**, captured as `rc=$?`. All 8 stages, 2,935 tests across 50 suites, coverage floors met, `npm audit` clean, gitleaks clean.
- **Prettier-formatted**, so the diff is the removal and nothing else.

## Relationship to #4

#4's version step already follows this declaration: it refuses `packages[].version` and `registryBaseUrl` when either is present, and carries no `runtimeArguments` assertion. Extracted that step and ran it with `GITHUB_REF_NAME=v1.0.0`:

| tree | exit | result |
| --- | --- | --- |
| this branch | `0` | `Version 1.0.0 agreed by the tag, package.json and all 3 server.json mentions of the image` |
| current `main` | `1` | refuses, naming both fields |

**Merge this before #4** — not because #4 depends on the file, but because `v1.0.0` is unpublishable until this lands.

## Supersedes

#6 proposed removing `runtimeArguments` alone, on the strength of a registry survey that covered an alphabetical prefix rather than the population, and did not address the two fields the validator actually rejects. Closed in favour of this.
