### PR TITLE
ci: cache the image build and keep untrusted code off the paid pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,24 @@ concurrency:
 jobs:
   gate:
     name: Quality gate (./build.sh)
-    runs-on: ubuntu-latest
+    # Trusted code runs on the self-hosted pool; untrusted code never does.
+    #
+    # A pull request whose head repository is THIS repository can only have been
+    # created by someone with push access — an org owner, a repository admin, or
+    # an invited collaborator. A fork pull request can be opened by anyone, so its
+    # code runs on GitHub-hosted runners, where a hostile workflow spends nothing
+    # of ours and reaches nothing of ours. `push` events are our own code by
+    # definition.
+    #
+    # The label lives in the TRUSTED_RUNNER repository variable rather than here,
+    # so the pool can be resized, renamed or retired without editing this file —
+    # and so this workflow behaves correctly while the variable is unset: every
+    # branch of the expression then evaluates to the GitHub-hosted runner.
+    runs-on: >-
+      ${{ (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (vars.TRUSTED_RUNNER || 'ubuntu-latest')
+          || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       # `persist-credentials: false` keeps the GITHUB_TOKEN out of
@@ -130,7 +147,24 @@ jobs:
 
   docker:
     name: Docker image (linux/amd64 + linux/arm64)
-    runs-on: ubuntu-latest
+    # Trusted code runs on the self-hosted pool; untrusted code never does.
+    #
+    # A pull request whose head repository is THIS repository can only have been
+    # created by someone with push access — an org owner, a repository admin, or
+    # an invited collaborator. A fork pull request can be opened by anyone, so its
+    # code runs on GitHub-hosted runners, where a hostile workflow spends nothing
+    # of ours and reaches nothing of ours. `push` events are our own code by
+    # definition.
+    #
+    # The label lives in the TRUSTED_RUNNER repository variable rather than here,
+    # so the pool can be resized, renamed or retired without editing this file —
+    # and so this workflow behaves correctly while the variable is unset: every
+    # branch of the expression then evaluates to the GitHub-hosted runner.
+    runs-on: >-
+      ${{ (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (vars.TRUSTED_RUNNER || 'ubuntu-latest')
+          || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -160,3 +194,11 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: false
+          # Without these, every run rebuilds both architectures from scratch,
+          # and the linux/arm64 half runs under QEMU emulation. That is the
+          # difference between a two-minute job and a seventeen-minute one, on
+          # the same commit. The GitHub Actions cache backend is scoped per
+          # branch with fallback to the default branch, so a pull request reuses
+          # main's layers and only rebuilds what it changed.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,10 @@ jobs:
     # it, so a rename has to update it here by hand, together with the slug in
     # package.json and the image reference in server.json.
     if: github.repository == 'tastytrade/tastytrade-mcp'
-    runs-on: ubuntu-latest
+    # A tag push is our own code by definition, so the gate may use the
+    # self-hosted pool. Falls back to the GitHub-hosted runner while the
+    # TRUSTED_RUNNER repository variable is unset.
+    runs-on: ${{ vars.TRUSTED_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -142,6 +145,15 @@ jobs:
   publish:
     name: Publish image to GHCR
     needs: gate
+    # DELIBERATELY GitHub-hosted, unlike every other job here.
+    #
+    # This is the only job that holds `packages: write`, and the only one whose
+    # output is the artifact an operator's `docker pull` resolves. A runner that
+    # builds it can substitute what it publishes. Releases are infrequent, so the
+    # minutes saved by moving this to a third-party pool are the cheapest minutes
+    # in the repository, and the integrity given up is the most expensive.
+    #
+    # Do not fold this into TRUSTED_RUNNER without deciding that trade separately.
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -451,6 +463,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.version.outputs.image }}
+          # Read the layers ci.yml warmed on the same commit, but do not write:
+          # a release must not seed a cache that later builds trust, and a cache
+          # entry is the one build input `provenance: mode=max` cannot attest.
+          cache-from: type=gha
           # BuildKit provenance (SLSA in-toto) plus an SBOM, attached to the
           # image in the registry. `mode=max` records the full build inputs,
           # which is the part that makes the attestation useful for answering


### PR DESCRIPTION
## Summary

Two changes to the same problem: the `Docker image` job is slow, and it is slow for a reason a cache alone does not fix.

**Measured on identical commits**, that job has taken **2m00s** and **17m+**. It has no build cache configured at all — no `cache-from`, no `cache-to` — so every run rebuilds both architectures from scratch, and the `linux/arm64` half runs under QEMU emulation. The 17-minute figure is what a cold emulated build costs on a busy runner. It stalled the merge queue for this release.

## Changes

### Build cache — `ci.yml`

```yaml
cache-from: type=gha
cache-to: type=gha,mode=max
```

The Actions cache backend is scoped per branch with fallback to the default branch, so a pull request reuses `main`'s layers and rebuilds only what it changed.

### Runner selection — `ci.yml`, both jobs

```yaml
runs-on: >-
  ${{ (github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository)
      && (vars.TRUSTED_RUNNER || 'ubuntu-latest')
      || 'ubuntu-latest' }}
```

A cache does not make emulation faster; native runners do. The condition is the trust boundary, not a preference:

| Trigger | Who can cause it | Runner |
| --- | --- | --- |
| `push` (main, tags) | someone with push access | `TRUSTED_RUNNER` |
| PR from a branch in this repo | org owner, repo admin, or invited collaborator — branch creation requires push access | `TRUSTED_RUNNER` |
| PR from a fork | **anyone on GitHub** | `ubuntu-latest` |

Fork pull requests are the abuse and cost vector for third-party runners on a public repository, and `ci.yml`'s `pull_request:` trigger is deliberately unrestricted so fork PRs do run. They stay on GitHub-hosted runners, where a hostile workflow spends nothing of ours and reaches nothing of ours.

The label lives in the **`TRUSTED_RUNNER` repository variable**, not in the workflow, so the pool can be resized, renamed or retired without a code change. **With the variable unset, every branch of the expression evaluates to `ubuntu-latest`** — so merging this changes no behaviour until the variable is set.

### Runner selection — `release.yml`

Its `gate` job follows the same variable; a tag push is our own code.

**Its `publish` job deliberately does not.** That job holds the only `packages: write` in the repository and produces the artifact an operator's `docker pull` resolves, so a runner that builds it can substitute what it publishes. Releases are infrequent, which makes those the cheapest minutes here to leave on the table. The comment in the file says so, and says not to fold it in without deciding that trade separately.

It reads the shared cache but does not write to it (`cache-from` only): a release should not seed layers that later builds trust, and a cache entry is the one build input `provenance: mode=max` cannot attest.

## Verification

- **`./build.sh` — exit code 0**, captured as `rc=$?`. All 8 stages, 2,930 tests across 50 suites.
- **Both workflows parse** (`yaml.safe_load`), and the resolved `runs-on` values are: `ci.yml` gate and docker → the conditional expression; `release.yml` gate → `${{ vars.TRUSTED_RUNNER || 'ubuntu-latest' }}`; `release.yml` publish → `ubuntu-latest`.
- **Job names are unchanged**, checked against the ruleset. `main-integrity` requires the contexts `Quality gate (./build.sh)` and `Docker image (linux/amd64 + linux/arm64)`; both jobs still carry exactly those `name:` values, so both checks still report. Renaming a job here would block every future PR on a check that never arrives.
- `actionlint` is not installed on this machine, so it was not run.

## Before setting `TRUSTED_RUNNER`

Two things to confirm against the provider, since neither is checkable from here:

1. **The exact runner label.** It goes in the variable, so no code change is needed to correct it.
2. **Any provider-supplied actions must be SHA-pinned.** This repository has `sha_pinning_required: true`, so a tag-pinned action is rejected at runtime. This PR adds no third-party actions.

## Follow-up (not in this PR)

If the pool provides native `linux/arm64` runners, splitting the docker job into per-architecture jobs and merging the manifest would remove emulation entirely rather than caching around it. That changes the job list, so it needs the ruleset's required contexts updated in the same change.