### PR TITLE
fix: check the order price against the published tick schedule

### DIFF
--- a/src/mcp-server/tool-metadata.ts
+++ b/src/mcp-server/tool-metadata.ts
@@ -3000,7 +3000,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
           items: {
             type: "string",
           },
@@ -3118,7 +3118,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
           items: {
             type: "string",
           },
@@ -3478,7 +3478,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
           items: {
             type: "string",
           },
@@ -3616,7 +3616,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
           items: {
             type: "string",
           },
@@ -3731,7 +3731,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
           items: {
             type: "string",
           },
@@ -3842,7 +3842,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
           items: {
             type: "string",
           },
@@ -5035,7 +5035,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
           items: {
             type: "string",
           },
@@ -5177,7 +5177,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
           items: {
             type: "string",
           },
@@ -5396,7 +5396,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids. A pre-flight evaluates only the three payload questions that gate token issuance (dry_run_readable, dry_run_errors, dry_run_described_order), so everything else in the catalogue is listed here: notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Those run on the matching live tool. Derived from the same predicate the dispatcher gates issuance on rather than written by hand.",
           items: {
             type: "string",
           },
@@ -5512,7 +5512,7 @@ export const TOOL_METADATA: Record<string, ToolMeta> = {
         checks_not_run: {
           type: "array",
           description:
-            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
+            "SERVER-AUTHORED. Which pre-submit checks this route did NOT evaluate, as stable ids: dry_run_readable, dry_run_errors, dry_run_described_order, notional_cap, per_leg_order_size, tick_size, account_frozen, account_closing_only, account_margin_call, account_risk_reducing_only. Derived from what the route actually ran rather than written by hand, so a check that could not be evaluated is disclosed instead of being absent. An empty array is a positive claim that the whole catalogue ran. The legless routes (edit_order, replace_order, edit_complex_order) always report per_leg_order_size and account_closing_only, because both read the order's legs and those bodies carry none; any account_* id appears when the trading-status read failed or answered with no readable flag.",
           items: {
             type: "string",
           },

--- a/src/safety/sanity-checks.ts
+++ b/src/safety/sanity-checks.ts
@@ -849,6 +849,8 @@ export const SANITY_CHECK_IDS = [
   "notional_cap",
   /** Per-leg quantity against the account's published order-size ceiling. */
   "per_leg_order_size",
+  /** Order price against the increment tastytrade publishes for the instrument. */
+  "tick_size",
   /** The account is not frozen. A HARD BLOCK; needs no legs. */
   "account_frozen",
   /** No leg opens a position on a closing-only account. Needs legs. */
@@ -1322,6 +1324,93 @@ export async function runStoredDryRunChecks(
   return { warnings, upstreamNotes, checksNotRun: deriveChecksNotRun(ran) };
 }
 
+// ---------------------------------------------------------------------------
+// Tick size
+//
+// tastytrade publishes the price increment per instrument, as an array where an
+// entry carrying a `threshold` applies BELOW that threshold and the single entry
+// without one is the fallback at and above every threshold. An equity leg reads
+// `tick-sizes`; an equity option leg reads `option-tick-sizes` off the SAME
+// underlying equity, which is why one instrument read covers both.
+//
+// Deliberately narrow. A multi-leg order prices against `spread-tick-sizes`, a
+// different schedule, and futures carry their own — guessing with the
+// single-leg equity schedule would be worse than saying nothing, so those cases
+// are named in checks_not_run instead. Anything unreadable lands there too: a
+// price this module could not check must never read as a price it approved.
+// ---------------------------------------------------------------------------
+
+/** Integer scale for the modulo. Eight places covers the 0.00005 futures tick. */
+const TICK_SCALE = 1e8;
+
+/** A finite scaled integer, or null when the value is not a usable decimal. */
+function scaledDecimal(value: unknown): number | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Math.round(n * TICK_SCALE);
+}
+
+/**
+ * The increment that applies to `price` under `schedule`, as a scaled integer.
+ *
+ * Returns null when the schedule is not an array of readable entries, or when it
+ * has no entry that applies — both of which mean "not checked", never "fine".
+ */
+export function tickForPrice(
+  schedule: unknown,
+  scaledPrice: number,
+): number | null {
+  if (!Array.isArray(schedule) || schedule.length === 0) return null;
+
+  let fallback: number | null = null;
+  const banded: Array<{ threshold: number; tick: number }> = [];
+
+  for (const entry of schedule) {
+    if (entry === null || typeof entry !== "object") return null;
+    const tick = scaledDecimal((entry as Record<string, unknown>).value);
+    if (tick === null || tick <= 0) return null;
+    const rawThreshold = (entry as Record<string, unknown>).threshold;
+    if (rawThreshold === undefined || rawThreshold === null) {
+      fallback = tick;
+      continue;
+    }
+    const threshold = scaledDecimal(rawThreshold);
+    if (threshold === null) return null;
+    banded.push({ threshold, tick });
+  }
+
+  banded.sort((a, b) => a.threshold - b.threshold);
+  for (const band of banded) {
+    if (scaledPrice < band.threshold) return band.tick;
+  }
+  return fallback;
+}
+
+/** The schedule field an instrument payload publishes for this leg's type. */
+function tickScheduleField(instrumentType: string): string | null {
+  if (instrumentType === "Equity") return "tick-sizes";
+  if (instrumentType === "Equity Option") return "option-tick-sizes";
+  return null;
+}
+
+/**
+ * The underlying equity symbol an OCC option symbol is written against.
+ *
+ * The root occupies the first six characters, space-padded. Returned trimmed, or
+ * null when there is nothing there to read.
+ */
+function occRoot(symbol: unknown): string | null {
+  if (typeof symbol !== "string") return null;
+  const root = symbol.slice(0, 6).trim();
+  return root.length > 0 ? root : null;
+}
+
+/** Human-readable form of a scaled integer, for the refusal message. */
+function unscale(scaled: number): string {
+  return String(scaled / TICK_SCALE);
+}
+
 /**
  * Run pre-submit checks. Throws a ToolError on hard-block conditions, returns
  * the accumulated soft-warning list otherwise. Caller should attach the
@@ -1490,6 +1579,70 @@ export async function runSanityChecks(
     // instrument-type from being echoed at size.
     if (sawCryptoLeg || unboundedTypes.size > 0) {
       warnings.push(UNCAPPED_LEG_BOUNDS);
+    }
+  }
+
+  // 2c. Order price against the published increment.
+  //
+  // A live read, like the limits above, and it fails the same way: a price off
+  // the increment is a HARD BLOCK, and a schedule that could not be read is
+  // named in checks_not_run rather than passed. Narrow by design — see the
+  // note above tickForPrice for why a spread and a futures leg are skipped
+  // rather than guessed at.
+  const scaledPrice = scaledDecimal(
+    (args as unknown as Record<string, unknown>).price,
+  );
+  const tickLeg = legs.length === 1 ? legs[0] : null;
+  const tickField = tickLeg
+    ? tickScheduleField(instrumentTypeOf(tickLeg))
+    : null;
+
+  if (scaledPrice === null || tickLeg === null || tickField === null) {
+    // Nothing to check, or nothing this module knows how to check. Silent: the
+    // absence is already reported by tick_size appearing in checks_not_run, and
+    // a warning on every market order would be noise.
+  } else {
+    const underlying =
+      tickField === "option-tick-sizes"
+        ? occRoot(tickLeg.symbol)
+        : typeof tickLeg.symbol === "string"
+          ? tickLeg.symbol
+          : null;
+    let schedule: unknown = null;
+    let read = false;
+    if (underlying !== null) {
+      try {
+        // GET /instruments/equities/{symbol} has a published 3/sec ceiling. The
+        // limiter has to know this endpoint is reached, for the same reason the
+        // trading-status charge above exists: an unbilled request is a request
+        // the ceiling does not govern.
+        chargeUpstreamCallDebt({ rateKey: "single_equity" });
+        const instrument = await client.getInstrument(underlying);
+        schedule = (instrument as Record<string, unknown> | null)?.[tickField];
+        read = true;
+      } catch {
+        read = false;
+      }
+    }
+    const tick = read ? tickForPrice(schedule, scaledPrice) : null;
+    if (tick === null) {
+      warnings.push(
+        `The price increment for ${describeSymbol(tickLeg.symbol)} could not be ` +
+          `read, so this order's price was not checked against a tick ` +
+          `schedule — ${SERVER_SIDE_BACKSTOP}`,
+      );
+    } else if (scaledPrice % tick !== 0) {
+      throw toolError({
+        code: "sanity_check_failed",
+        message:
+          `Leg 0 (${describeSymbol(tickLeg.symbol)}): price ` +
+          `${unscale(scaledPrice)} is not a multiple of the published ` +
+          `increment ${unscale(tick)}.`,
+        retryable: false,
+        hint: "Round the price to the instrument's increment and re-run the matching dry_run_* tool for a fresh token. The schedule is published as tick-sizes (equities) and option-tick-sizes (options on that equity) on GET /instruments/equities/{symbol}.",
+      });
+    } else {
+      ran.add("tick_size");
     }
   }
 

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -205,6 +205,40 @@ function claimsAccountDirectory(route: Route): boolean {
   );
 }
 
+/** Matches any single-equity instrument read: /instruments/equities/{symbol}. */
+const EQUITY_INSTRUMENT_RE = /\/instruments\/equities\/[^/]+$/;
+
+/**
+ * A tick schedule for every equity, so the submit path's tick check has
+ * something to read.
+ *
+ * Installed for the same reason the account-directory default is, and refused
+ * for the same reason: a suite that routes this path specifically is testing
+ * what the check does with a particular schedule and must win, while a suite
+ * ending in a catch-all only meant "answer everything I did not name". Without
+ * a default the check reports an unreadable schedule, which attaches a warning
+ * to every order in the file and drowns whatever each suite is asserting — the
+ * position-limit payload had exactly this problem.
+ *
+ * 0.01 for equities and a 3.00-thresholded 0.05/0.10 for options are the real
+ * shapes; see test/e2e/_payloads/tastytrade_get_option_chain_nested.json.
+ */
+const DEFAULT_EQUITY_INSTRUMENT = {
+  "tick-sizes": [{ value: "0.01" }],
+  "option-tick-sizes": [{ threshold: "3.0", value: "0.05" }, { value: "0.1" }],
+};
+
+function claimsEquityInstrument(route: Route): boolean {
+  const probe = "/instruments/equities/AAPL";
+  if (typeof route.matcher === "string") {
+    return EQUITY_INSTRUMENT_RE.test(route.matcher);
+  }
+  return (
+    route.matcher.test(probe) &&
+    !route.matcher.test("/an-unrelated-path-no-suite-routes")
+  );
+}
+
 function normalizeHeaders(config: AxiosRequestConfig): Record<string, string> {
   const out: Record<string, string> = {};
   const raw = (config.headers ?? {}) as Record<string, unknown>;
@@ -268,6 +302,15 @@ export async function createHarness(
       },
     });
   }
+  if (!routes.some(claimsEquityInstrument)) {
+    // Unshifted for the same ordering reason as the directory default above.
+    routes.unshift({
+      matcher: EQUITY_INSTRUMENT_RE,
+      method: "GET",
+      reply: { data: DEFAULT_EQUITY_INSTRUMENT },
+    });
+  }
+
   const requests: RecordedRequest[] = [];
   const fallback: RouteReply = options.fallback ?? { status: 200, data: {} };
 

--- a/test/e2e/orders.test.ts
+++ b/test/e2e/orders.test.ts
@@ -898,10 +898,13 @@ describe("single order: dry_run_order -> place_order", () => {
       upstream_notes: string[];
     };
 
-    // The full round trip: pre-flight, the two sanity reads, then the live POST.
+    // The full round trip: pre-flight, the three sanity reads, then the live
+    // POST. The instrument read is the tick check fetching the price increment
+    // published for the leg's underlying.
     expect(trace(h)).toEqual([
       `POST /accounts/${ACCT}/orders/dry-run`,
       `GET /accounts/${ACCT}/position-limit`,
+      `GET /instruments/equities/AAPL`,
       `GET /accounts/${ACCT}/trading-status`,
       `POST /accounts/${ACCT}/orders`,
     ]);

--- a/test/e2e/rate-limits.test.ts
+++ b/test/e2e/rate-limits.test.ts
@@ -707,9 +707,13 @@ describe("the order path pays for the requests it actually makes", () => {
 
     await placeOne(h);
 
-    // dry-run POST (1 tool call, 1 request) + place_order (1 tool call, 3
-    // requests) = 4 broker requests, and 4 global tokens.
-    expect(h.requests).toHaveLength(4);
+    // dry-run POST (1 tool call, 1 request) + place_order (1 tool call, 4
+    // requests: position-limit, the instrument read the tick check needs,
+    // trading-status, then the order POST) = 5 broker requests, and 5 global
+    // tokens. The instrument read is also charged to its own single_equity
+    // bucket, so the submit path costs one token more than the number of
+    // safety questions it answers.
+    expect(h.requests).toHaveLength(5);
     let spent = 0;
     for (;;) {
       try {
@@ -719,7 +723,7 @@ describe("the order path pays for the requests it actually makes", () => {
         break;
       }
     }
-    expect(spent).toBe(GLOBAL_PER_SECOND - 4);
+    expect(spent).toBe(GLOBAL_PER_SECOND - 5);
   });
 
   it("bills the trading-status GET to its own published 1/sec bucket", async () => {

--- a/test/safety/sanity-checks.test.ts
+++ b/test/safety/sanity-checks.test.ts
@@ -18,6 +18,7 @@ import {
   ADVISORY_READ_BUDGET_MS,
   DEFAULT_MAX_ORDER_NOTIONAL_USD,
   ORDER_LEG_INSTRUMENT_TYPES,
+  tickForPrice,
   UNCEILINGED_ORDER_LEG_INSTRUMENT_TYPES,
   type OutboundOrderBody,
 } from "../../src/safety/sanity-checks.js";
@@ -70,6 +71,8 @@ function makeClient(
     status?: unknown;
     limitErr?: boolean;
     statusErr?: boolean;
+    instrument?: unknown;
+    instrumentErr?: boolean;
   } = {},
 ): TastytradeClient {
   const client = {
@@ -78,6 +81,10 @@ function makeClient(
       // `in`, not `??`: the null and undefined payloads are themselves under
       // test, and `??` would quietly substitute the default for both.
       return "limits" in opts ? opts.limits : ALL_LIMITS;
+    }),
+    getInstrument: jest.fn(async () => {
+      if (opts.instrumentErr) throw new Error("instrument endpoint down");
+      return "instrument" in opts ? opts.instrument : AAPL_INSTRUMENT;
     }),
     getAccountStatus: jest.fn(async () => {
       if (opts.statusErr) throw new Error("status endpoint down");
@@ -91,6 +98,21 @@ function makeClient(
   };
   return client as unknown as TastytradeClient;
 }
+
+/**
+ * The equity instrument payload the tick check reads.
+ *
+ * Both schedules are here because the check picks between them by leg instrument
+ * type: `tick-sizes` for an Equity leg, `option-tick-sizes` for an Equity Option
+ * leg. A thresholded entry applies BELOW its threshold; the entry without one is
+ * the fallback at and above every threshold. Shapes taken from
+ * test/e2e/_payloads/tastytrade_get_option_chain_nested.json.
+ */
+const AAPL_INSTRUMENT = {
+  symbol: "AAPL",
+  "tick-sizes": [{ value: "0.01" }],
+  "option-tick-sizes": [{ threshold: "3.0", value: "0.05" }, { value: "0.1" }],
+};
 
 const ACCT = "5WX34382";
 
@@ -2169,6 +2191,7 @@ describe("a broker note cannot enter the server's own verdict channel", () => {
     expect(res.checksNotRun).toEqual([
       "dry_run_described_order",
       "per_leg_order_size",
+      "tick_size",
       "account_closing_only",
     ]);
   });
@@ -2281,5 +2304,179 @@ describe("the dry-run note COUNT is bounded, and the omission is disclosed", () 
     expect(e.toolError.message).toContain("Dry-run blocked");
     expect(e.toolError.message.length).toBeLessThan(10_000);
     expect(e.toolError.message).toMatch(/omitted/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tick size
+//
+// The order price has to be an increment the venue accepts. tastytrade publishes
+// the schedule per instrument, so this is a live read like the position limits,
+// and it fails the same way: a violation is a HARD BLOCK, and a schedule that
+// could not be read is named in checks_not_run rather than passed.
+// ---------------------------------------------------------------------------
+
+function optionLeg(quantity = 1, action = "Buy to Open"): OutboundOrderBody {
+  return {
+    legs: [
+      {
+        "instrument-type": "Equity Option",
+        symbol: "AAPL  270115C00007000",
+        action,
+        quantity,
+      },
+    ],
+  };
+}
+
+const echoed = { ...cleanDryRun, order: ORDER_ECHO };
+
+describe("runSanityChecks — tick size", () => {
+  it("hard-blocks an option limit price off the published increment", async () => {
+    // 1.63 against a 0.05 increment: a dry-run returned clean on exactly this
+    // shape, minted a token, and the order would have died at exchange routing.
+    const e = await captureRejection(
+      runSanityChecks(
+        makeClient(),
+        ACCT,
+        { ...optionLeg(), price: "1.63" },
+        echoed,
+      ),
+    );
+    expect(isToolErrorException(e)).toBe(true);
+    if (isToolErrorException(e)) {
+      expect(e.toolError.code).toBe("sanity_check_failed");
+      // Carries what the leg-action error carries: which leg, which symbol,
+      // what was expected, what arrived.
+      expect(e.toolError.message).toMatch(/Leg 0/);
+      expect(e.toolError.message).toContain("AAPL  270115C00007000");
+      expect(e.toolError.message).toContain("0.05");
+      expect(e.toolError.message).toContain("1.63");
+      expect(e.toolError.retryable).toBe(false);
+    }
+  });
+
+  it("accepts a price on the increment and records the check as run", async () => {
+    const client = makeClient();
+    const res = await runSanityChecks(
+      client,
+      ACCT,
+      { ...optionLeg(), price: "1.60" },
+      echoed,
+    );
+    expect(res.checksNotRun).not.toContain("tick_size");
+    // Asserted explicitly: `not.toContain` alone would also hold if the check
+    // did not exist, so it has to say that the schedule was actually fetched,
+    // and fetched for the OCC root rather than the contract symbol.
+    expect(client.getInstrument).toHaveBeenCalledWith("AAPL");
+  });
+
+  it("picks the equity schedule for an equity leg", async () => {
+    // 6.005 is off AAPL's 0.01 equity increment and would be off the option
+    // schedule too, so this fails whichever is chosen — what it proves is that
+    // an equity leg is checked at all.
+    const e = await captureRejection(
+      runSanityChecks(
+        makeClient(),
+        ACCT,
+        { ...equityLeg(1), price: "6.005" },
+        echoed,
+      ),
+    );
+    expect(isToolErrorException(e)).toBe(true);
+  });
+
+  it("applies the threshold: the fallback increment at and above it", async () => {
+    // 3.15 sits on the 0.05 thresholded increment but off the 0.1 fallback that
+    // applies at and above 3.0. A read that ignored the threshold would pass it.
+    const e = await captureRejection(
+      runSanityChecks(
+        makeClient(),
+        ACCT,
+        { ...optionLeg(), price: "3.15" },
+        echoed,
+      ),
+    );
+    expect(isToolErrorException(e)).toBe(true);
+  });
+
+  it("names the check as not run when the instrument read fails", async () => {
+    const res = await runSanityChecks(
+      makeClient({ instrumentErr: true }),
+      ACCT,
+      { ...optionLeg(), price: "1.63" },
+      echoed,
+    );
+    // Not a pass: an unreadable schedule must never look like a checked price.
+    expect(res.checksNotRun).toContain("tick_size");
+    expect(res.warnings.join(" ")).toMatch(/tick/i);
+  });
+
+  it("names the check as not run for a multi-leg order", async () => {
+    // A spread prices against spread-tick-sizes, a different schedule.
+    const twoLegs: OutboundOrderBody = {
+      legs: [
+        ...(optionLeg().legs ?? []),
+        ...(optionLeg(1, "Sell to Open").legs ?? []),
+      ],
+      price: "0.85",
+    };
+    const res = await runSanityChecks(makeClient(), ACCT, twoLegs, echoed);
+    expect(res.checksNotRun).toContain("tick_size");
+  });
+
+  it("names the check as not run when the order carries no price", async () => {
+    const res = await runSanityChecks(makeClient(), ACCT, optionLeg(), echoed);
+    expect(res.checksNotRun).toContain("tick_size");
+  });
+});
+
+describe("tickForPrice", () => {
+  // Scaled integers: the helper works in hundred-millionths so a decimal price
+  // never meets floating-point modulo. 1e8 covers the 0.00005 futures tick.
+  const S = 1e8;
+  const at = (n: number) => Math.round(n * S);
+
+  it("picks the band a price falls below, across several thresholds", () => {
+    // Three bands, deliberately supplied out of order: the helper sorts them,
+    // and with fewer than two banded entries that sort is never exercised.
+    const schedule = [
+      { threshold: "10.0", value: "0.10" },
+      { value: "0.25" },
+      { threshold: "1.0", value: "0.01" },
+      { threshold: "3.0", value: "0.05" },
+    ];
+    expect(tickForPrice(schedule, at(0.5))).toBe(at(0.01));
+    expect(tickForPrice(schedule, at(2.0))).toBe(at(0.05));
+    expect(tickForPrice(schedule, at(5.0))).toBe(at(0.1));
+    // At and above every threshold, the entry carrying none.
+    expect(tickForPrice(schedule, at(50))).toBe(at(0.25));
+  });
+
+  it("treats a threshold as exclusive at its own value", () => {
+    const schedule = [{ threshold: "3.0", value: "0.05" }, { value: "0.1" }];
+    expect(tickForPrice(schedule, at(2.99))).toBe(at(0.05));
+    expect(tickForPrice(schedule, at(3.0))).toBe(at(0.1));
+  });
+
+  it("returns null for anything it cannot read, rather than guessing", () => {
+    // Every one of these means "not checked". A helper that fell back to a
+    // default increment here would turn an unreadable schedule into a passed
+    // price, which is the failure this whole check exists to prevent.
+    expect(tickForPrice(undefined, at(1))).toBeNull();
+    expect(tickForPrice(null, at(1))).toBeNull();
+    expect(tickForPrice([], at(1))).toBeNull();
+    expect(tickForPrice("0.05", at(1))).toBeNull();
+    expect(tickForPrice([null], at(1))).toBeNull();
+    expect(tickForPrice(["0.05"], at(1))).toBeNull();
+    expect(tickForPrice([{ value: "nope" }], at(1))).toBeNull();
+    expect(tickForPrice([{ value: "0" }], at(1))).toBeNull();
+    expect(tickForPrice([{ value: "-0.05" }], at(1))).toBeNull();
+    expect(tickForPrice([{ threshold: "x", value: "0.05" }], at(1))).toBeNull();
+    // A schedule with only bands and no fallback: nothing applies at or above
+    // the highest threshold.
+    expect(
+      tickForPrice([{ threshold: "3.0", value: "0.05" }], at(4)),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

A limit price off the instrument's increment reached the exchange. The dry-run returned clean, minted a confirmation token, and the order died at routing — the broker's own preflight rejects other malformed orders (market-closed, closing more than held, session timing) but not this one, so the venue was the only thing catching it.

`runSanityChecks` now reads the published increment and refuses a price that is not a multiple of it.

## Where it sits, and why

At **submit**, alongside the per-leg size check — not at dry-run. It needs a live read, and a dry-run deliberately makes none. That is the same protection model the notional cap and the position limits already use: the token is minted on a clean pre-flight, and the check hard-blocks when the token is spent.

## How the schedule reads

tastytrade publishes it as an array where an entry carrying a `threshold` applies **below** that threshold, and the single entry without one is the fallback at and above every threshold:

```json
[{ "threshold": "3.0", "value": "0.05" }, { "value": "0.1" }]
```

So 1.63 is checked against 0.05 and 3.15 against 0.10. An **equity** leg reads `tick-sizes`; an **equity option** leg reads `option-tick-sizes` off the *same underlying equity* — confirmed against the OpenAPI reference, which puts `option-tick-sizes` on the Equity object as *"Tick size rules for options on this equity"* — so one instrument read covers both.

Comparison is in scaled integers (hundred-millionths). A decimal modulo in binary floating point does not answer this question.

## Deliberately narrow

Named in `checks_not_run`, not guessed at:

| case | why |
| --- | --- |
| multi-leg order | prices against `spread-tick-sizes`, a different schedule |
| futures / future options | carry their own schedule and endpoint |
| instrument read failed | an unreadable schedule is not a passed price |
| no price on the order | a Market order has nothing to check |

A price that was not checked must never read as a price that passed, so each of those also attaches a warning where a caller would otherwise see silence.

## Cost, stated plainly

The submit path now makes **one more request**: `GET /instruments/equities/{symbol}`. It has a published 3/sec ceiling and is charged to the `single_equity` bucket. `test/e2e/rate-limits.test.ts` asserts the new count of 5, because a request the limiter does not know about is a request its ceiling does not govern — and that assertion is what caught the charge being missing in the first draft of this change.

## Verification

- **`./build.sh` — exit code 0**, captured as `rc=$?`. 2,940 tests across 50 suites, coverage floors met, audit clean, gitleaks clean.
- **Written test-first.** The seven behavioural cases were run before any implementation existed: 6 failed, and the 7th was strengthened afterwards to assert `getInstrument` was called with the OCC root, because `not.toContain("tick_size")` alone would also hold if the check did not exist.
- **Mutation-checked.** Disabling the refusal (`else if (false && …)`) makes 3 tests fail; restoring it makes all 7 pass, and the file is byte-identical to the pre-mutation copy (`cmp`).
- **`tickForPrice` is unit-tested directly**, including a multi-band schedule supplied out of order — with fewer than two banded entries the sort comparator is never invoked, which is how the 100% function floor on `src/safety/` caught an untested path.
- Eleven unreadable-schedule shapes assert `null` rather than a default increment.

## Test-harness change

`test/e2e/harness.ts` gains a default `/instruments/equities/{symbol}` route, installed and overridable exactly like the existing account-directory default. Without it the check reports an unreadable schedule on every order and drowns whatever each suite is asserting — the position-limit payload had this same problem, and the comments there describe the fix this copies.

## Follow-up (not in this PR)

A `stop-trigger` is also a venue price and is not yet checked. Same schedule, same code path; left out to keep this change to one assertion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tastytrade/codesmith/tastytrade-mcp/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790559382&installation_model_id=434762&pr_number=19&repository=tastytrade%2Ftastytrade-mcp&return_to=https%3A%2F%2Fgithub.com%2Ftastytrade%2Ftastytrade-mcp%2Fpull%2F19&signature=175f34fab5e70533f3c77c0e3ba7c9b68ba64b04ac63886d761fe508dd3b142e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->