### PR TITLE
Make .env.sample name the environment the docs promise

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,18 +27,23 @@
 # SANDBOX and prints a banner on stderr saying so. Unset is a default; a typo is
 # a failed instruction, and the two must not land in the same place.
 #
-# The line below selects the sandbox, which is the cautious place to start. Be
-# aware of what you are trading away: the sandbox currently answers every
-# market-data and market-metrics route with HTTP 502, so quotes and market
-# metrics do not work there. Instruments, option chains, futures, accounts,
-# balances, positions, orders and the dry-run/order paths all do.
+# The line below names PRODUCTION, matching the default and matching the
+# paste-ready blocks in README.md and server.json. It is written out rather than
+# left off on purpose: a file that ships one environment while the documentation
+# promises another sends whoever copies it somewhere they did not choose, and
+# they find out from a fill.
 #
-# When you are ready for real money, set this to `production` or delete the
-# line. The server prints an unmissable stderr banner on every production
-# start, and tells the connected agent the same thing in the `instructions` it
-# returns on initialize. Set TASTYTRADE_READ_ONLY=1 to keep every write and
-# destructive tool withheld while you look around.
-TASTYTRADE_ENV=sandbox
+# TO USE THE SANDBOX, change it to `sandbox`. Know what you are trading away:
+# the sandbox currently answers every market-data and market-metrics route with
+# HTTP 502, so quotes and market metrics do not work there. Instruments, option
+# chains, futures, accounts, balances, positions, orders and the dry-run/order
+# paths all do.
+#
+# Whichever you pick, TASTYTRADE_READ_ONLY=1 withholds and refuses every write
+# and destructive tool while you look around. On production the server also
+# prints an unmissable stderr banner at startup and tells the connected agent
+# the same thing in the `instructions` it returns on initialize.
+TASTYTRADE_ENV=production
 
 # ---- TASTYTRADE_API_URL: only for a host that is not tastytrade's own ------
 #

--- a/test/server-manifest.test.ts
+++ b/test/server-manifest.test.ts
@@ -27,6 +27,7 @@ import {
   TastytradeMCPServer,
 } from "../src/mcp-server/index.js";
 import { accessClassFor } from "../src/mcp-server/annotations.js";
+import { apiEnvironmentOf, resolveApiUrl } from "../src/mcp-server/index.js";
 import { REQUIRED_DOCS } from "../src/resources/static/vendored-docs.js";
 
 const REPO_ROOT = path.resolve(
@@ -246,11 +247,39 @@ describe("the two paste-ready configs cannot disagree", () => {
     expect(readmeEnvValues().length).toBeGreaterThan(0);
   });
 
-  it("selects the SAME environment in both", () => {
+  /** The uncommented TASTYTRADE_ENV assignment in .env.sample, if any. */
+  function envSampleValue(): string | undefined {
+    for (const line of read(".env.sample").split("\n")) {
+      const m = /^TASTYTRADE_ENV=(.*)$/.exec(line.trim());
+      if (m) return m[1].trim();
+    }
+    return undefined;
+  }
+
+  it("selects the SAME environment in all THREE paste-ready artifacts", () => {
+    // README.md, server.json and .env.sample are each a block somebody copies.
+    // A reader meets ONE of them, so if they disagree, some fraction of users
+    // land in an environment the documentation did not promise — and on this
+    // server the two environments differ by whether orders spend real money.
+    //
+    // This test previously compared only the first two. .env.sample shipped
+    // `TASTYTRADE_ENV=sandbox` while both others named production, and an agent
+    // that copied the sample reported the server had "defaulted to sandbox" —
+    // correctly, for the file it had been handed.
     const fromManifest = manifestEnv().TASTYTRADE_ENV;
     for (const value of readmeEnvValues()) {
       expect(value).toBe(fromManifest);
     }
+    expect(envSampleValue()).toBe(fromManifest);
+  });
+
+  it("does not let .env.sample contradict the resolver's own default", () => {
+    // Stronger than agreement between documents: what the sample names must be
+    // what an unconfigured server actually does. Read from the resolver rather
+    // than restated, so this cannot drift if the default moves again.
+    const sample = envSampleValue();
+    expect(sample).toBeDefined();
+    expect(apiEnvironmentOf(resolveApiUrl({}))).toBe(sample);
   });
 
   it("selects an environment the server can actually read", () => {


### PR DESCRIPTION
## Summary

This repository ships **three** paste-ready configuration blocks, and a reader meets one of them, not all three:

| artifact | named |
|---|---|
| `README.md` | `production` |
| `server.json` | `production` |
| `.env.sample` | **`sandbox`** |

On this server the two environments differ by whether an order spends real money, so anyone who copied the sample ended up somewhere the documentation had not promised — and would have found out from a fill.

## Changes

- `.env.sample` now names `production`, written out rather than left off, with a comment that explains the choice and says plainly how to reach the sandbox instead. The market-data caveat is kept: the sandbox answers every market-data and market-metrics route with HTTP 502, which is worth knowing before choosing it.
- **The consistency test compared README against server.json and stopped there** — which is why this sat unnoticed. It now covers all three.
- It also adds a stronger assertion than agreement between documents: what the sample names must equal what `resolveApiUrl` returns for an empty environment, read from the resolver rather than restated, so it cannot drift if the default moves again.

## Verification

- `./build.sh` — exit 0, all 8 stages, **3,058 tests**.
- Mutation-checked: restoring `TASTYTRADE_ENV=sandbox` in the sample **fails two tests**.

## Note on provenance

This surfaced while investigating a report that a fresh install had "defaulted to sandbox". That turned out to be the connected agent choosing sandbox on its own, not this file — a fresh `git clone` of `main`, built and started with `env -i`, reports `PRODUCTION (https://api.tastyworks.com)` and fires the live-money banner. So this is not the cause of that report. It is a real inconsistency found on the way, and worth closing on its own merits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tastytrade/codesmith/tastytrade-mcp/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790786887&installation_model_id=434762&pr_number=31&repository=tastytrade%2Ftastytrade-mcp&return_to=https%3A%2F%2Fgithub.com%2Ftastytrade%2Ftastytrade-mcp%2Fpull%2F31&signature=7788a108efa46644cb026745737106f15b65cc7eebe543712abcc16a7fa0ada8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->